### PR TITLE
Added fields on Ofo

### DIFF
--- a/Ofo.md
+++ b/Ofo.md
@@ -126,6 +126,8 @@ curl --request POST \
 	"values": {
 		"cars": [
 			{
+				"carno": "PzeDlM",
+				"bomNum": "5CA",
 				"userIdLast": "1",
 				"lng": 2.3796870561551,
 				"lat": 48.839922829334


### PR DESCRIPTION
New usefull fields returned.
I think `carno` is a kind of ID and `bomNum` maybe the bike version (i saw `5CA`, `3OA` and `0`)