### PR TITLE
Motivate GeoJSON APIs!

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ Returns 50 nearest bikes.
 
 All APIs and data are also listed on `https://www.motivateco.com/use-our-data/`
 
+Motivate also has undocumented APIs in the GeoJSON format. URLs might be tricky to divine for other cities, but Washington DC & NYC are:
+ * https://layer.bicyclesharing.net/map/v1/wdc/map-inventory
+ * https://layer.bicyclesharing.net/map/v1/nyc/map-inventory
+
 ## BYKE (Germany)
 
 Simple GET-Request example: `https://api-prod.ibyke.io/v1/bikes?latitude=52.55001&longitude=13.40902&order=nearby`


### PR DESCRIPTION
I got shown some un-authenticated GeoJSON APIs for CaBi & CitiBike... :smiling_imp:

I assume all other motivate operated cities could work too, but I haven't deduced what their URLs are. (I guessed `nyc`)