### PR TITLE
Change URL params

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ This endpoint is more well-documented in the file
 ## VOI (Europe)
 [VOI](https://voiscooters.com) is a scooter sharing company founded in Sweden. They have electric scooters available at several locations in Europe, including cities in Sweden, Spain, Italy, France and others. A simple GET request to get scooters available for rental nearby a location (specified with latitude/longtitude parameters) looks like this:
 
-`https://api.voiapp.io/v1/vehicle/status/ready?la=59.329323&lo=18.068581`
+`https://api.voiapp.io/v1/vehicle/status/ready?lat=59.329323&lng=18.068581`
 
 (**no authentication is needed**)
 

--- a/Voi.md
+++ b/Voi.md
@@ -24,7 +24,7 @@ These are the known accepted request parameters:
 
 There are also other `status` available. Change the `ready` in the url to one of these: `'ready', 'bounty', 'riding', 'home', 'collected', 'lost'`
 
-An example request is: `https://api.voiapp.io/v1/vehicle/status/ready?la=59.329323&lo=18.068581`.
+An example request is: `https://api.voiapp.io/v1/vehicle/status/ready?lat=59.329323&lng=18.068581`.
 
 **The server will return a response formatted like this:**
 


### PR DESCRIPTION
"la/lo" not working for VOI API. Instead "lat/lng" is a working solution