### PR TITLE
Change Mobike subdomain

### DIFF
--- a/Mobike.md
+++ b/Mobike.md
@@ -29,7 +29,7 @@
 
 ```bash
 curl --request POST \
-     --url http://app.mobike.com/api/nearby/v4/nearbyBikeInfo \
+     --url http://global-n-mobike-g.mobike.com/api/nearby/v4/nearbyBikeInfo \
      --header 'platform: 1' \
      --header 'Content-Type: application/x-www-form-urlencoded' \
      --header 'User-Agent: Mozilla/5.0 (Android 7.1.2; Pixel Build/NHG47Q) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.9 NTENTBrowser/3.7.0.496 (IWireless-US) Mobile Safari/537.36' \


### PR DESCRIPTION
Mobike seemingly changed the request-subdomain from `app` to `global-n-mobike-g`.
With this commit, the example should work again.