### PR TITLE
Carsharing provider cambio

### DIFF
--- a/Cambio.md
+++ b/Cambio.md
@@ -1,0 +1,26 @@
+# Cambio
+
+[Cambio](https://https://www.cambio-carsharing.de/) is a carsharing company based in Germany and [Belgium](https://www.cambio.be/en-bxl).
+
+There is *no* authentication or special headers and only `GET`-Requests required for their region-specific API-Endpoints:
+
+
+Country | City / Region | Eurocode | Link
+--- | --- | --- | ---
+DE | Aachen | AAC | https://cwapi.cambio-carsharing.com/pub/AAC/stations
+DE | Berlin | BRL | https://cwapi.cambio-carsharing.com/pub/BRL/stations
+DE | Bielefeld | BIL | https://cwapi.cambio-carsharing.com/pub/BIL/stations
+DE | Bremen | BRE | https://cwapi.cambio-carsharing.com/pub/BRE/stations
+DE | Flensburg | FLB | https://cwapi.cambio-carsharing.com/pub/FLB/stations
+DE | Hamburg | HAM | https://cwapi.cambio-carsharing.com/pub/HAM/stations
+DE | Köln | KOE | https://cwapi.cambio-carsharing.com/pub/KOE/stations
+DE | Lüneburg | LBG | https://cwapi.cambio-carsharing.com/pub/LBG/stations
+DE | Oldenburg | OLD | https://cwapi.cambio-carsharing.com/pub/OLD/stations
+DE | Saarbrücken | SAB | https://cwapi.cambio-carsharing.com/pub/SAB/stations
+DE | Wuppertal | WUP | https://cwapi.cambio-carsharing.com/pub/WUP/stations
+BE | Brussels | BXL | https://cwapi.cambio-carsharing.com/pub/BXL/stations
+BE | Wallonia | WAL | https://cwapi.cambio-carsharing.com/pub/WAL/stations
+BE | Flanders | VLA | https://cwapi.cambio-carsharing.com/pub/VLA/stations
+
+Deeplinks follow this pattern, where BRE is the Eurocode, 2936 the station ID.
+https://www.cambio-carsharing.de/station/BRE/2936.html

--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ Public transport and multimodal routing apps could benefit from showing nearby b
 - [Coup (Germany, Spain, France)](Coup.md)
 - [Stella (Germany (Stuttgart))](Stella.md)
 
+## Cars
+- [Cambio (Germany, Belgium)](Cambio.md)
+
+
 ## More...
 * Also have a look at [this project](https://github.com/eskerda/pybikes/tree/master/pybikes)
 * [GBFS (General Bikeshare Feed Specification)](https://github.com/NABSA/gbfs)


### PR DESCRIPTION
This PR adds the first carsharing provider to WoBike. Cambio permits external use of it's API endpoints.