### PR TITLE
Update GBFS Lime.md

### DIFF
--- a/Lime.md
+++ b/Lime.md
@@ -1,5 +1,31 @@
 # Lime
 
+### GBFS
+
+In select cities, a GBFS feed is also available. Louisville is one for example.
+
+**URL** `https://data.lime.bike/api/partners/v1/gbfs/<city>/gbfs.json`
+
+## Cities
+| United States  | Germany, Austria and Switzerland | France    | Canada   | Israel    | Norway and Italy | Australia and New Zealand | Belgium   |
+|----------------|----------------------------------|-----------|----------|-----------|------------------|---------------------------|-----------|
+| baltimore      | hamburg                          | paris     | kelowna  | tel_aviv  | oslo             | auckland                  | antwerp   |
+| cleveland      | oberhausen                       | marseille | edmonton |           | rome             | sydney                    | brussels  |
+| detroit        | opfikon                          | paris     |          |           | verona           |                           |           |
+| grand_rapids   | reutlingen                       |           |          |           |                  |                           |           |
+| new_york       | solingen                         |           |          |           |                  |                           |           |
+| norfolk_va     | zug                              |           |          |           |                  |                           |           |
+| washington_dc  |                                  |           |          |           |                  |                           |           |
+| colorado_springs|                                  |           |          |           |                  |                           |           |
+| louisville     |                                  |           |          |           |                  |                           |           |
+| oakland        |                                  |           |          |           |                  |                           |           |
+| san_francisco  |                                  |           |          |           |                  |                           |           |
+| san_jose       |                                  |           |          |           |                  |                           |           |
+| seattle        |                                  |           |          |           |                  |                           |           |
+| chicago        |                                  |           |          |           |                  |                           |           |
+
+
+---
 **Base URL**: `https://web-production.lime.bike/api/rider`
 
 ## Methods to authenticate
@@ -384,11 +410,7 @@ If you get a 404 "Resource not found" message, it's most likely because the ET-I
 | ------------- | ------------ | :-------: |
 | Authorization | Bearer TOKEN | X         |
 
-### GBFS
 
-In select cities, a GBFS feed is also available. Louisville is one for example.
-
-**URL** `https://data.lime.bike/api/partners/v1/gbfs/<city>/gbfs.json`
 
 The Juicer API can be found here: https://github.com/davidwim/lime-juicer/
 


### PR DESCRIPTION
## 🚀 Update of Available Cities for GBFS

Updated the list of available cities for Lime's GBFS (General Bikeshare Feed Specification) data exchange system.

## Changes Made:

- Added new cities available for GBFS integration.
- Updated documentation information to reflect the newly added cities.
